### PR TITLE
PR mainly stop exposing mysql port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
 version: '3'
 services:
   mysql:
+    container_name: mysql
     image: mariadb:10.3.17
-    command: --max_allowed_packet=256M
+    command: --max_allowed_packet=256M --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - "./data/db:/var/lib/mysql:delegated"
-    ports:
-       - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
   litespeed:
+    container_name: litespeed
     image: litespeedtech/litespeed:${LSWS_VERSION}-${PHP_VERSION}
     env_file:
       - .env
@@ -31,10 +31,10 @@ services:
     restart: always
     environment:
       TZ: ${TimeZone}
-  phpmyadmin:
-    image: bitnami/phpmyadmin:latest
+  adminer:
+    container_name: adminer
+    image: adminer
     ports:
-      - 8080:80
-      - 8443:443
+      - 8080:8080
     environment:
-        DATABASE_HOST: mysql
+        ADMINER_DEFAULT_SERVER: mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     restart: always
     environment:
       TZ: ${TimeZone}
+  memcached:
+    container_name: memcached
   adminer:
     container_name: adminer
     image: adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,9 @@ services:
     restart: always
     environment:
       TZ: ${TimeZone}
-  memcached:
-    container_name: memcached
+  redis:
+    container_name: redis
+    image: redis:alpine
   adminer:
     container_name: adminer
     image: adminer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   mysql:
     container_name: mysql
-    image: mariadb:10.3.17
+    image: mariadb:10
     command: --max_allowed_packet=256M --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     volumes:
       - "./data/db:/var/lib/mysql:delegated"


### PR DESCRIPTION
1. by using container_name we are able to stop exposing mysql to internet.
2. the adminer container is official and lighter than phpmyadmin, but it's a personal choice